### PR TITLE
Strip nested map keys

### DIFF
--- a/cfn/encoding/unstringify.go
+++ b/cfn/encoding/unstringify.go
@@ -210,8 +210,14 @@ func convertType(t reflect.Type, i interface{}) (reflect.Value, error) {
 // Unstringify takes a stringified representation of a value
 // and populates it into the supplied interface
 func Unstringify(data map[string]interface{}, v interface{}) error {
-	t := reflect.TypeOf(v).Elem()
+	clean := make(map[string]interface{})
+	for k := range data {
+		val := data[k]
+		strippedKey := strings.Replace(k, "/", "", 1)
+		clean[strippedKey] = val
+	}
 
+	t := reflect.TypeOf(v).Elem()
 	val := reflect.ValueOf(v).Elem()
 
 	for i := 0; i < t.NumField(); i++ {
@@ -223,7 +229,7 @@ func Unstringify(data map[string]interface{}, v interface{}) error {
 			jsonName = jsonTag[0]
 		}
 
-		if value, ok := data[jsonName]; ok {
+		if value, ok := clean[jsonName]; ok {
 			newValue, err := convertType(f.Type, value)
 			if err != nil {
 				return err


### PR DESCRIPTION
Key mismatch between map keys and interface field names causes indexing issues here. Strip map keys to handle the translation of nested structs.